### PR TITLE
Adding feature to show both directions of routes (plus formatting and more documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This project is a modded Cleveland version of the [dc-metro](https://github.com/
 It uses the same hardware and general display, with capability to poll the [Greater Cleveland Regional Transit Authority](http://www.riderta.com/)
 live trip updates and ⌚.
 
-🚨🚨🚨 At some point in 2024, the legacy RTA service this board uses has a broken frontend. This unfortunately means you can't set this project up any more.
 
 It uses a friendly version of Micropython (which is Python meant for
 embedded devices) called CircuitPython. CP is developed by the makers of the hardware, [Adafruit](https://www.adafruit.com/), who makes and sells 
@@ -15,7 +14,7 @@ educational and hobby electronics/coding products, provides great resources and 
 
 # How To
 ## Hardware Needed
-- An [Adafruit Matrix Portal](https://www.adafruit.com/product/4745) - $24.99
+- An [Adafruit Matrix Portal](https://www.adafruit.com/product/4745) - $24.95
   - This is a single board microcontroller, a.k.a. *a small computer*
 - A **64x32 RGB LED matrix** compatible with the _Matrix Portal_ - $39.99 _to_ $84.99
     - [64x32 RGB LED Matrix - 3mm pitch](https://www.adafruit.com/product/2279) Smallest, finer grid
@@ -56,17 +55,17 @@ The board needs to regularly synchronize its onboard clock using a free time ser
 
 ## Transit board config
 
-The board should reload and start showing you default routes! You now need to configure it to your liking. 
+The board will  reload and start showing you default routes! **You now need to configure it to show your desired stops/routes.**
 
 ### Customize your stops in the *config.py*.  
 
 9. Each route/stop/direction combination requires a Python dict with these 3 key:values. The 3rd key, *params*, is a nested dictionary object with 6 key-values.
     - route_name: *str*, what will display, like "26" or "HL"
     - route_color: *int*, hex color for bar (e.g. 0xff0000 for red)
-    - params: *dict*, the GCRTA Next Connect API request parameters, explained below
-      - 'routeID': ⚠ *Get from NextConnect*  
-      - 'directionID': ⚠ _Get from NextConnect_  
-      - 'stopID': ⚠ _Get from NextConnect_  
+    - params: *dict*, GCRTA's Live Departure service request parameters, explained below
+      - 'routeID': ⚠ *Get from Live Departures*  
+      - 'directionID': ⚠ _Get from Live Departures_  
+      - 'stopID': ⚠ _Get from Live Departures_  
       - 'cutoff': *int* Trips arriving sooner than this time will be tossed out because they are impossible to reach the stop in time
       - 'tpID': 0,
       - 'useArrivalTimes': 'false'
@@ -74,13 +73,14 @@ The board should reload and start showing you default routes! You now need to co
 **The board can only fit 3 rows on it.** If you are fetching more than 3 routes, it will display the 3
 soonest arrivals in order of their arrival
 
-### Gettings `params` from GCRTA NextConnect
+### Gettings `params` from GCRTA Live Departures
 
-10. Go to [GCRTA NextConnect Live Departure Times](http://nextconnect.riderta.com/LiveDepartureTimes). This is an endpoint that delivers
+10. Go to Live Departures on [GCRTA homepage](https://www.riderta.com/). This service is powered by web service that delivers
 live departure updates from RTA's TransitMaster system, which is the central brain of RTA's operations, scheduling, and 
-serving the RTA real time feed. This board essentially simulates using this website. 🚨 This doesn't work any more. Sorry people, I'm looking for alternatives 🚨
+serving the RTA real time feed. This board essentially simulates using the RTA website. **You need collect 2 lists of route config entries: one for each direction of the route.**
+
 11. For each route/direction/stop combo, you need to:
-    1. Enter the desired route, direction, and stop on NextConnect.
+    1. Enter the desired route, direction, and stop on Live Departures.
     2. Open devtools for your browser (Ctrl + Shift + I) --*Chrome is recommended if you aren't familiar with this*
     3. Go to "Network" tab
     4. Wait up to 15 seconds for the browser to fetch the update again (it automatically does this)
@@ -88,5 +88,9 @@ serving the RTA real time feed. This board essentially simulates using this webs
     6. Click on *Payload*
     7. Use the parameters from that payload to fill out the `params` dict in the desired route dict.
 
-## Finish line
-12. Upon saving your `config.py` with your desired routes, the board will reboot and populate with your configured route/direction/stops. 🎉🎉🎉
+    Store the first set of config entries in `routes_in` list.
+
+    Collect the same information for the opposite direction in `routes_out` list. See `config.py` for details.
+
+## Finish Line 🏁🎉
+12. Upon saving your `config.py` with your desired routes, the board will reboot and populate with your configured route/direction/stops.

--- a/src/api.py
+++ b/src/api.py
@@ -7,9 +7,7 @@ import time
 # Set up parameters
 url_nextconnect = config["api_url"]
 seconds_1day = 24 * 60 * 60  # 24 hours x 60 minutes x 60 seconds
-network_reset = 1  # minutes before starting network
-
-routes = config["routes"]
+routes = config["routes_in"]
 
 
 class RealTimeAPI:
@@ -25,7 +23,7 @@ class RealTimeAPI:
                 route["params"],
                 route["cutoff"],
             )
-            time.sleep(0.5)
+            time.sleep(0.1)
             if not update:
                 continue
             results.append(update)

--- a/src/time_set.py
+++ b/src/time_set.py
@@ -5,11 +5,12 @@ import rtc
 import time
 
 time_format = "%Y-%m-%d %H:%M:%S.%L %j %u %z %Z"
-time_zone = config['timezone']
+time_zone = config["timezone"]
 
 TIME_SERVICE = (
     "https://io.adafruit.com/api/v2/%s/integrations/time/strftime?x-aio-key=%s"
 )
+
 
 def url_encode(url):
     """
@@ -20,7 +21,8 @@ def url_encode(url):
     url = url.replace(":", "%3A")
     return url
 
-def get_strftime(time_format= time_format, location=time_zone):
+
+def get_strftime(time_format=time_format, location=time_zone):
     """
     Fetch a custom strftime relative to your location.
     :param str location: Your city and country, e.g. ``"America/New_York"``.
@@ -49,8 +51,7 @@ def get_strftime(time_format= time_format, location=time_zone):
         if response.status_code != 200:
             print(response)
             error_message = (
-                "Error connecting to Adafruit IO. The response was: "
-                + response.text
+                "Error connecting to Adafruit IO. The response was: " + response.text
             )
             raise RuntimeError
         reply = response.text

--- a/src/train_board.py
+++ b/src/train_board.py
@@ -10,119 +10,180 @@ from config import config
 
 class TrainBoard:
     """
-        get_new_data is a function that is expected to return an array of dictionaries like this:
-        [
-            {
-                'line_color': 0xFFFFFF,
-                'destination': 'Dest Str',
-                'arrival': '5'
-            }
-        ]
+    get_new_data is a function that is expected to return an array of dictionaries like this:
+    [
+        {
+            'line_color': 0xFFFFFF,
+            'destination': 'Dest Str',
+            'arrival': '5'
+        }
+    ]
     """
+
     def __init__(self, get_new_data):
         self.get_new_data = get_new_data
         self.matrix = Matrix(bit_depth=3)
         self.display = self.matrix.display
-        # self.display.auto_refresh = False
-
+        # Memory of last call of get_new_data
+        self.direction_state = "in"
+        self.in_cache = []
+        self.out_cache = []
         # create parent group for entire display relative positioning
         self.parent_group = displayio.Group()
 
         # loading indicator
-        self.loading_dot = Rect(width=2, height=2, x=0,y=0, fill=0x000055)
-        self.loading_dot_grp = displayio.Group(x=61,y=29)
+        self.loading_dot = Rect(width=2, height=2, x=0, y=0, fill=0x000055)
+        self.loading_dot_grp = displayio.Group(x=61, y=29)
         self.loading_dot_grp.append(self.loading_dot)
         self.parent_group.append(self.loading_dot_grp)
         # setup header row showing LINE DESTINATION MINUTES
-        self.heading_label = Label(x=0, y=0, font=config['time_font'], anchor_point=(0,0), anchored_position= (0,0))
-        self.heading_label.color = config['heading_color']
-        self.heading_label.text=config['heading_text']
+        self.heading_label = Label(
+            x=0,
+            y=0,
+            font=config["time_font"],
+            anchor_point=(0, 0),
+            anchored_position=(0, 0),
+        )
+        self.heading_label.color = config["heading_color"]
+        self.heading_label.text = config["heading_text"]
         self.parent_group.append(self.heading_label)
 
         # add small clock at bottom
-        self.time_update = Label(anchored_position=(32, 27),
-                                 font=config['time_font'],
-                                 anchor_point=(0.5, 0),
-                                 color= 0x000055,
-                                 )
+        self.time_update = Label(
+            anchored_position=(32, 27),
+            font=config["time_font"],
+            anchor_point=(0.5, 0),
+            color=0x000055,
+        )
 
-        self.time_update.text = config['loading_time_msg']
+        self.time_update.text = config["loading_time_msg"]
         self.parent_group.append(self.time_update)
 
         # instantiate configured number of rows (trains) on board and add to parent group
         self.trains = []
 
-        for i in range(config['num_routes_display']):
-            self.trains.append(Train(self.parent_group, index= i))
+        for i in range(config["num_routes_display"]):
+            self.trains.append(Train(self.parent_group, index=i))
 
         # display parent displayio group on board
         self.display.show(self.parent_group)
         self.display.refresh()
 
-    def refresh(self) -> bool:
+    def refresh(self, routes: list = None, cached_data=None, direction="in") -> bool:
+        """This will update the board by grabbing fresh info from GCRTA and updating visuals.
+        If cached_data is passed True, then it will simply pass cached data to the update process
+
+        Args:
+            routes (list, optional): Which route_list to use, inbound or outbound. Defaults to None.
+            cached_data (boolean, optional): Flag for using cached arrival info. Defaults to None.
+            direction (str, optional): Which direction for each stop to update. Defaults to 'in'.
+
+        Returns:
+            None
+        """
         # prep time stamp for clock update
         cur_hour = time.localtime().tm_hour
         cur_min = time.localtime().tm_min
-        tstamp = f'{cur_hour}:{cur_min:0>2}'
-        print(f'{tstamp} Refreshing train information...')
-
+        tstamp = f"{cur_hour}:{cur_min:0>2}"
+        train_data = None
         # call function fetch_predictions from main api.py, get parsed list
-        train_data = self.get_new_data()
+        if cached_data:
+            if direction == "in":
+                # Pass the cached inbound data to the following update procedure
+                train_data = self.in_cache
+            if direction == "out":
+                # Pass the cached inbound data to the following update procedure
+                train_data = self.out_cache
+        else:
+            # Primary call to grab new information from GCRTA
+            train_data = self.get_new_data(routes)
+            # Store last fetch of updates for cycling results between API calls
+            if direction == "in":
+                self.in_cache = train_data
+                self.direction_state = "in"
+            if direction == "out":
+                self.out_cache = train_data
+                self.direction_state = "out"
 
         if train_data is not None:
-            for i in range(config['num_routes_display']):
-                if i < len(train_data): # if haven't exceeded the configured # of routes, then update the that trip (called "train" due to previous project)
+            for i in range(config["num_routes_display"]):
+                if i < len(
+                    train_data
+                ):  # if haven't exceeded the configured # of routes, then update the that trip (called "train" due to previous project)
                     train = train_data[i]
-                    if not train['arrival']:
+                    if not train["arrival"]:
                         self._hide_train(i)
                     else:
-                        self._update_train(i,
-                        train['line_color'],
-                        train['route_name'],
-                        train['destination'],
-                        train['arrival']
+                        self._update_train(
+                            i,
+                            train["line_color"],
+                            train["route_name"],
+                            train["destination"],
+                            train["arrival"],
                         )
                 else:
                     self._hide_train(i)
-            self.time_update.text = tstamp # update clock
+            self.time_update.text = tstamp  # update clock
         else:
-            print('No data received. Clearing display.')
-            for i in range(config['num_routes']):
+            print("No data received. Clearing display.")
+            for i in range(config["num_routes"]):
                 self._hide_train(i)
 
     def _hide_train(self, index: int):
         self.trains[index].hide()
 
-    def _update_train(self, index: int, line_color: int, route: str, destination: str, minutes: str):
+    def _update_train(
+        self, index: int, line_color: int, route: str, destination: str, minutes: str
+    ):
         self.trains[index].update(line_color, route, destination, minutes)
+
+    def flip_direction(self):
+        if self.direction_state == "in":
+            self.refresh(routes=config["routes_out"], cached_data=True, direction="out")
+            self.direction_state = "out"
+            print("Flipped to outbound")
+        elif self.direction_state == "out":
+            self.refresh(routes=config["routes_in"], cached_data=True, direction="in")
+            self.direction_state = "in"
+            print("Flipped to inbound")
 
 
 class Train:
     def __init__(self, parent_group, index):
-        y = (index+1) * 7 - 1
-        self.line_rect = Rect(x=0, y=0, width=config['train_line_width'], height=config['train_line_height'], fill=config['loading_line_color'])
+        y = (index + 1) * 7 - 1
+        self.line_rect = Rect(
+            x=0,
+            y=0,
+            width=config["train_line_width"],
+            height=config["train_line_height"],
+            fill=config["loading_line_color"],
+        )
 
-        self.route_label = Label(x=config['text_padding'], y=3, font=config['font'])
-        self.route_label.color = config['text_color']
-        self.route_label.text = config['loading_route_text']
+        self.route_label = Label(x=config["text_padding"], y=3, font=config["font"])
+        self.route_label.color = config["text_color"]
+        self.route_label.text = config["loading_route_text"]
 
         # self.destination_label = Label(x=18, y=3, font=config['font'])
         # self.destination_label.color = config['text_color']
         # self.destination_label.text = config['loading_destination_text']
 
-        self.destination_label = Label(x=14,
-          y=3, text=config['loading_destination_text'],
-          # max_characters = config['destination_max_characters'],
-          # animate_time = 0.3,
-          font=config['font'])
-        self.destination_label.color = config['dest_color']
+        self.destination_label = Label(
+            x=14,
+            y=3,
+            text=config["loading_destination_text"],
+            # max_characters = config['destination_max_characters'],
+            # animate_time = 0.3,
+            font=config["font"],
+        )
+        self.destination_label.color = config["dest_color"]
 
         self.min_label = Label(
-            anchor_point = (1.0,0.0),
-            anchored_position = (config['matrix_width'],0),
-            font=config['font'],
-            text=config['loading_min_text'])
-        self.min_label.color = config['text_color']
+            anchor_point=(1.0, 0.0),
+            anchored_position=(config["matrix_width"], 0),
+            font=config["font"],
+            text=config["loading_min_text"],
+        )
+        self.min_label.color = config["text_color"]
 
         self.group = displayio.Group(x=0, y=y)
         self.group.append(self.line_rect)
@@ -147,15 +208,15 @@ class Train:
         self.route_label.text = route[:]
 
     def set_destination(self, destination: str):
-        self.destination_label.text = ''  # setting destination to empty because the full destination makes the board
-        # too busy. Considering adding an Inbound (I) Outbound (O) letter after route name instead
+        self.destination_label.text = ""  # setting destination to empty because the full destination makes the board
+        # too busy. Condirectionring adding an Inbound (I) Outbound (O) letter after route name instead
         # may add an option to add scrolling text later
 
     def set_arrival_time(self, minutes: str):
         minutes_len = len(minutes)
 
         # Left-padding the minutes label
-        minutes = ' ' * (config['min_label_characters'] - minutes_len) + minutes
+        minutes = " " * (config["min_label_characters"] - minutes_len) + minutes
 
         self.min_label.text = minutes
 


### PR DESCRIPTION
- Removing warnings about not being able to set up the project.
    - RTA in fact moved the service to their home page, and it is fully operational 🙌
    - This project doesn't have to die, yay.
    - The live departure API is no longer branded as "NextConnect"—that page's frontend died last year, making it impossible to gather parameters to set up the board with desired stops.
- Add core function to show both directions of routes (plus formatting and more documentation).
    - Users are now expected to configure inbound and outbound routes.
    - The board will cycle from showing both directions in between fetching live updates from RTA
    - Still recommend about 4-5 routes in either direction maximum.
   